### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build_base_image.yaml
+++ b/.github/workflows/build_base_image.yaml
@@ -16,7 +16,7 @@ jobs:
           run: echo "::set-output name=new_tag::$(echo "${{ github.ref }}" | sed -e "s/refs\/heads\///g" | sed -e "s/refs\/tags\///g" | sed -e "s/\//\-/g" | sed 's#+#_#g')"
 
         - name: Publish Base Image to Registry
-          uses: elgohr/Publish-Docker-Github-Action@master
+          uses: elgohr/Publish-Docker-Github-Action@v5
           with:
             name: quay.io/vgsi/dotnet-sonarscanner:${{ steps.out_step.outputs.new_tag }}
             username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore